### PR TITLE
Support Erlang 24 by using mac/3

### DIFF
--- a/lib/signaturex/crypto_helper.ex
+++ b/lib/signaturex/crypto_helper.ex
@@ -4,7 +4,7 @@ defmodule Signaturex.CryptoHelper do
   """
   @spec hmac256_to_string(binary, binary) :: binary
   def hmac256_to_string(app_secret, to_sign) do
-    :crypto.hmac(:sha256, app_secret, to_sign)
+    hmac(:sha256, app_secret, to_sign)
     |> hexlify
     |> :string.to_lower
     |> List.to_string
@@ -37,5 +37,14 @@ defmodule Signaturex.CryptoHelper do
   defp md5(data), do: :crypto.hash(:md5, data)
   defp hexlify(binary) do
     :lists.flatten(for b <- :erlang.binary_to_list(binary), do: :io_lib.format("~2.16.0B", [b]))
+  end
+
+  # borrowed from
+  # https://github.com/elixir-plug/plug_crypto/blob/master/lib/plug/crypto/message_verifier.ex#L97-L102
+  # to support Erlang < 22 (hmac/3) and Erlang >= 24 (mac/4)
+  if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+    defp hmac(digest, key, data), do: :crypto.mac(:hmac, digest, key, data)
+  else
+    defp hmac(digest, key, data), do: :crypto.hmac(digest, key, data)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Signaturex.Mixfile do
       name: "Signaturex",
       description: @description,
       elixir: "~> 1.5",
-      version: "1.3.0",
+      version: "1.3.1",
       package: package(),
       deps: deps(),
       source_url: "https://github.com/edgurgel/signaturex" ]

--- a/mix.exs
+++ b/mix.exs
@@ -16,10 +16,12 @@ defmodule Signaturex.Mixfile do
       source_url: "https://github.com/edgurgel/signaturex" ]
   end
 
-  def application, do: []
+  def application do
+    [ extra_applications: [:crypto] ]
+  end
 
   defp deps do
-    [{ :meck, "~> 0.8.2", only: :test },
+    [{ :meck, "~> 0.9.2", only: :test },
      { :earmark, "~> 1.0", only: :dev },
      { :ex_doc, "~> 0.16", only: :dev }]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "meck": {:hex, :meck, "0.8.3", "4628a1334c69610c5bd558b04dc78d723d8ec5445c123856de34c77f462b5ee5", [:rebar], [], "hexpm"}}
+%{
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm", "3b1dcad3067985dd8618c38399a8ee9c4e652d52a17a4aae7a6d6fc4fcc24856"},
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "b6fb4aef8125c62e6b6a7d7507eff70f376a7050c7745af11f08333ea9beebd3"},
+  "meck": {:hex, :meck, "0.9.2", "85ccbab053f1db86c7ca240e9fc718170ee5bda03810a6292b5306bf31bae5f5", [:rebar3], [], "hexpm", "81344f561357dc40a8344afa53767c32669153355b626ea9fcbc8da6b3045826"},
+}


### PR DESCRIPTION
In Erlang 24, the `hmac/4` function has been removed. `mac/3` replaces
it, but `mac/3` is only available in Erlang >= 22. Support both
depending on what the `:crypto` module exports.

Also fix a `meck`-related compile error by updating to the latest
version:

```
$ mix deps.compile
==> meck (compile)
src/meck_code_gen.erl:182:42: erlang:get_stacktrace/0 is removed; use the new try/catch syntax for retrieving the stack backtrace
Compiling src/meck_code_gen.erl failed:
ERROR: compile failed while processing signaturex/deps/meck: rebar_abort
** (Mix) Could not compile dependency :meck, "elixir/1.12.2/.mix/rebar compile skip_deps=true deps_dir="signaturex/_build/test/lib"" command failed. You can recompile this dependency with "mix deps.compile meck", update it with "mix deps.update meck" or clean it with "mix deps.clean meck"
```

Also fix a compile warning about the application setup and `crypto` by
adding `extra_applications` to the `mix.exs` file:

```
warning: :crypto.hash/2 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

  lib/signaturex/crypto_helper.ex:37: Signaturex.CryptoHelper.md5/1
```

Fixes #8.